### PR TITLE
Adjust references to use 4.5 instead of 4.5.2

### DIFF
--- a/src/OneSignal.CSharp.SDK/OneSignal.CSharp.SDK.csproj
+++ b/src/OneSignal.CSharp.SDK/OneSignal.CSharp.SDK.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OneSignal.CSharp.SDK</RootNamespace>
     <AssemblyName>OneSignal.CSharp.SDK</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -37,7 +37,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net452\RestSharp.dll</HintPath>
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/OneSignal.CSharp.SDK/packages.config
+++ b/src/OneSignal.CSharp.SDK/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This addresses issue #14 and uses library references for 4.5 instead of 4.5.2