### PR TITLE
Simplify the namespace from OneSignal.CSharp.SDK to OneSignal

### DIFF
--- a/src/OneSignal.CSharp.SDK/IOneSignalClient.cs
+++ b/src/OneSignal.CSharp.SDK/IOneSignalClient.cs
@@ -1,7 +1,7 @@
-﻿using OneSignal.CSharp.SDK.Resources.Notifications;
-using OneSignal.CSharp.SDK.Resources.Devices;
+﻿using OneSignal.Resources.Notifications;
+using OneSignal.Resources.Devices;
 
-namespace OneSignal.CSharp.SDK
+namespace OneSignal
 {
     /// <summary>
     /// OneSignal client interface.

--- a/src/OneSignal.CSharp.SDK/OneSignal.CSharp.SDK.csproj
+++ b/src/OneSignal.CSharp.SDK/OneSignal.CSharp.SDK.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -6,7 +6,7 @@
     <ProjectGuid>{81900249-B891-4B10-99B4-9810D793C8CF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>OneSignal.CSharp.SDK</RootNamespace>
+    <RootNamespace>OneSignal</RootNamespace>
     <AssemblyName>OneSignal.CSharp.SDK</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/OneSignal.CSharp.SDK/OneSignalClient.cs
+++ b/src/OneSignal.CSharp.SDK/OneSignalClient.cs
@@ -1,5 +1,5 @@
-﻿using OneSignal.CSharp.SDK.Resources.Devices;
-using OneSignal.CSharp.SDK.Resources.Notifications;
+﻿using OneSignal.Resources.Devices;
+using OneSignal.Resources.Notifications;
 
 namespace OneSignal.CSharp.SDK
 {

--- a/src/OneSignal.CSharp.SDK/Resources/BaseResource.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/BaseResource.cs
@@ -1,6 +1,6 @@
 ﻿using RestSharp;
 
-namespace OneSignal.CSharp.SDK.Resources
+namespace OneSignal.Resources
 {
     /// <summary>
     /// Abstract class which helps easier implementation of new client resources.

--- a/src/OneSignal.CSharp.SDK/Resources/Devices/DeviceAddOptions.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Devices/DeviceAddOptions.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace OneSignal.CSharp.SDK.Resources.Devices
+namespace OneSignal.Resources.Devices
 {
     /// <summary>
     /// Options for adding new device to OneSignal app.

--- a/src/OneSignal.CSharp.SDK/Resources/Devices/DeviceAddResult.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Devices/DeviceAddResult.cs
@@ -1,6 +1,6 @@
 ﻿using RestSharp.Deserializers;
 
-namespace OneSignal.CSharp.SDK.Resources.Devices
+namespace OneSignal.Resources.Devices
 {
     /// <summary>
     /// Class used to keep result of device add operation.

--- a/src/OneSignal.CSharp.SDK/Resources/Devices/DeviceEditOptions.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Devices/DeviceEditOptions.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace OneSignal.CSharp.SDK.Resources.Devices
+namespace OneSignal.Resources.Devices
 {
     /// <summary>
     /// Options for editing existing device defined in OneSignal app.

--- a/src/OneSignal.CSharp.SDK/Resources/Devices/DeviceTypeEnum.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Devices/DeviceTypeEnum.cs
@@ -1,4 +1,4 @@
-﻿namespace OneSignal.CSharp.SDK.Resources.Devices
+﻿namespace OneSignal.Resources.Devices
 {
     /// <summary>
     /// Device types enum.

--- a/src/OneSignal.CSharp.SDK/Resources/Devices/DevicesResource.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Devices/DevicesResource.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using OneSignal.CSharp.SDK.Serializers;
+using OneSignal.Serializers;
 using RestSharp;
 
-namespace OneSignal.CSharp.SDK.Resources.Devices
+namespace OneSignal.Resources.Devices
 {
     /// <summary>
     /// Implementation of BaseResource, used to help client add or edit device.

--- a/src/OneSignal.CSharp.SDK/Resources/Devices/IDevicesResource.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Devices/IDevicesResource.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace OneSignal.CSharp.SDK.Resources.Devices
+namespace OneSignal.Resources.Devices
 {
     /// <summary>
     /// Interface used to unify creation of classes used to help client add or edit device.

--- a/src/OneSignal.CSharp.SDK/Resources/Devices/TestTypeEnum.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Devices/TestTypeEnum.cs
@@ -1,4 +1,4 @@
-﻿namespace OneSignal.CSharp.SDK.Resources.Devices
+﻿namespace OneSignal.Resources.Devices
 {
     /// <summary>
     /// Test type enumeration.

--- a/src/OneSignal.CSharp.SDK/Resources/LanguageCodes.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/LanguageCodes.cs
@@ -1,4 +1,4 @@
-﻿namespace OneSignal.CSharp.SDK.Resources
+﻿namespace OneSignal.Resources
 {
     /// <summary>
     /// Language codes constants for supported languages.
@@ -9,7 +9,7 @@
         /// <summary>
         /// Language code for English language.
         /// </summary>		
-        public const string English="en";
+        public const string English = "en";
 
         /// <summary>
         /// Language code for Arabic language.
@@ -21,15 +21,15 @@
         /// </summary>		
         public const string Catalan = "ca";
 
-/// <summary>
-/// Language code for Chinese(Simplified) language.
-/// </summary>		
-public const string ChineseSimplified = "zh-Hans";
+        /// <summary>
+        /// Language code for Chinese(Simplified) language.
+        /// </summary>		
+        public const string ChineseSimplified = "zh-Hans";
 
-/// <summary>
-/// Language code for Chinese(Traditional) language.
-/// </summary>		
-public const string ChineseTraditional = "zh-Hant";
+        /// <summary>
+        /// Language code for Chinese(Traditional) language.
+        /// </summary>		
+        public const string ChineseTraditional = "zh-Hant";
 
         /// <summary>
         /// Language code for Croatian language.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/ActionButtonField.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/ActionButtonField.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Class used to describe action field.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/AndroidBackgroundLayoutField.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/AndroidBackgroundLayoutField.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Class used to describe android background layout of the notification message displayed in device.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/CustomConverters.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/CustomConverters.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Globalization;
-using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     #region CustomDateTimeConverter
     /// <summary>

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/Enums.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/Enums.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using RestSharp.Deserializers;
-
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+﻿namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Types of visibility for apps targeting Android API level 21+ running on Android 5.0+ devices.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/INotificationFilter.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/INotificationFilter.cs
@@ -1,4 +1,4 @@
-﻿namespace OneSignal.CSharp.SDK.Resources.Notifications
+﻿namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Interface used to unify Notification Filter classes.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/INotificationsResource.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/INotificationsResource.cs
@@ -1,4 +1,4 @@
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Interface used to unify Notification Resource classes.
@@ -18,7 +18,7 @@ namespace OneSignal.CSharp.SDK.Resources.Notifications
         /// <param name="options">This parameter contains the information required to cancel a scheduled notification</param>
         /// <returns>Returns result of notification cancel operation.</returns>
         NotificationCancelResult Cancel(NotificationCancelOptions options);
-      
+
         /// <summary>
         /// Get report about notification
         /// </summary>

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationCancelOptions.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationCancelOptions.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// API Documentation: https://documentation.onesignal.com/docs/notifications-cancel-notification

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationCancelResult.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationCancelResult.cs
@@ -1,7 +1,6 @@
-﻿using Newtonsoft.Json;
-using RestSharp.Deserializers;
+﻿using RestSharp.Deserializers;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Result of notification cancel operation.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationCreateOptions.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationCreateOptions.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Converters;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// API Documentation: https://documentation.onesignal.com/docs/notifications-create-notification

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationCreateResult.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationCreateResult.cs
@@ -1,6 +1,6 @@
 ﻿using RestSharp.Deserializers;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Result of notification create operation.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationFilterField.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationFilterField.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Complex type used to describe filter field.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationFilterOperator.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationFilterOperator.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Notification filter operator is used to define logical AND, OR 

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationViewOptions.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationViewOptions.cs
@@ -1,9 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using Newtonsoft.Json.Converters;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Get delivery and convert report about single notification.
@@ -24,7 +22,6 @@ namespace OneSignal.CSharp.SDK.Resources.Notifications
         /// </summary>
         [JsonProperty("id")]
         public Guid Id { get; set; }
-
 
     }
 }

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationViewResult.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationViewResult.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using RestSharp.Deserializers;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Delivery and convert report result refered to single notification.
@@ -41,7 +40,6 @@ namespace OneSignal.CSharp.SDK.Resources.Notifications
         [JsonProperty("remaining")]
         public int Remaining { get; set; }
 
-
         /// <summary>
         /// The number of remaining devices where notification will be delivered
         /// </summary>
@@ -75,7 +73,7 @@ namespace OneSignal.CSharp.SDK.Resources.Notifications
         [JsonProperty("contents")]
         [JsonExtensionData]
         public Dictionary<string, string> Contents { get; set; }
-        
+
         /// <summary><br/>
         /// The notification's title, a map of language codes to text for each language.<br/>
         /// Each hash must have a language code string for a key, mapped to the localized text you would like users to receive for that language.<br/>

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationsResource.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/NotificationsResource.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Net;
-using OneSignal.CSharp.SDK.Serializers;
+using OneSignal.Serializers;
 using RestSharp;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Class used to define resources needed for client to manage notifications.

--- a/src/OneSignal.CSharp.SDK/Resources/Notifications/WebButtonField.cs
+++ b/src/OneSignal.CSharp.SDK/Resources/Notifications/WebButtonField.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace OneSignal.CSharp.SDK.Resources.Notifications
+namespace OneSignal.Resources.Notifications
 {
     /// <summary>
     /// Class used to describe web button.

--- a/src/OneSignal.CSharp.SDK/Serializers/NewtonsoftJsonSerializer.cs
+++ b/src/OneSignal.CSharp.SDK/Serializers/NewtonsoftJsonSerializer.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using RestSharp.Serializers;
 
-namespace OneSignal.CSharp.SDK.Serializers
+namespace OneSignal.Serializers
 {
     /// <summary>
     /// Custom implementation to Json serializer in order to comply with REST Sharp requirements.


### PR DESCRIPTION
This fixes issue #17.
In order to publish a new release, a bump of the major version is in order to warn people of the impact.